### PR TITLE
Use fixed Node and Yarn versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,11 +26,29 @@ First, install [Bazel](https://docs.bazel.build/versions/master/install.html) an
 Next, create a `WORKSPACE` file in your project root containing:
 
 ```python
+# Required for access to js_library, js_test, web_bundle, etc.
 git_repository(
   name = "bazel_javascript",
   remote = "https://github.com/zenclabs/bazel-javascript.git",
   tag = "0.0.16",
 )
+
+# Required for underlying dependencies such as Node and Yarn.
+git_repository(
+    name = "build_bazel_rules_nodejs",
+    remote = "https://github.com/bazelbuild/rules_nodejs.git",
+    tag = "0.10.0",
+)
+
+load("@build_bazel_rules_nodejs//:defs.bzl", "node_repositories")
+
+# By default, the Node and Yarn versions you have installed locally will be
+# ignored, and Bazel will install a separate version instead. This helps
+# achieve consistency across teams.
+#
+# See https://github.com/bazelbuild/rules_nodejs if you'd like to use your
+# local Node and Yarn binaries instead.
+node_repositories(package_json = [])
 ```
 
 ## Basic example

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,1 +1,11 @@
 workspace(name = "bazel_javascript")
+
+git_repository(
+    name = "build_bazel_rules_nodejs",
+    remote = "https://github.com/bazelbuild/rules_nodejs.git",
+    tag = "0.10.0",
+)
+
+load("@build_bazel_rules_nodejs//:defs.bzl", "node_repositories")
+
+node_repositories(package_json = [])

--- a/internal/js_binary/rule.bzl
+++ b/internal/js_binary/rule.bzl
@@ -2,7 +2,7 @@ load("//internal/js_library:rule.bzl", "JsLibraryInfo")
 load("//internal/npm_packages:rule.bzl", "NpmPackagesInfo")
 
 def _js_binary_impl(ctx):
-  ctx.actions.run_shell(
+  ctx.actions.run(
     inputs = [
       ctx.file._js_binary_compile_script,
       ctx.attr._internal_packages[NpmPackagesInfo].installed_dir,
@@ -12,8 +12,10 @@ def _js_binary_impl(ctx):
     outputs = [
       ctx.outputs.executable_file,
     ],
-    command = "NODE_PATH=" + ctx.attr._internal_packages[NpmPackagesInfo].installed_dir.path + "/node_modules node \"$@\"",
-    use_default_shell_env = True,
+    executable = ctx.file._internal_nodejs,
+    env = {
+      "NODE_PATH": ctx.attr._internal_packages[NpmPackagesInfo].installed_dir.path + "/node_modules"
+    },
     arguments = [
       # Run `node js_binary/compile.js`.
       ctx.file._js_binary_compile_script.path,
@@ -51,6 +53,11 @@ js_binary = rule(
         "production",
       ],
       default = "none",
+    ),
+    "_internal_nodejs": attr.label(
+      allow_files = True,
+      single_file = True,
+      default = Label("@nodejs//:node"),
     ),
     "_internal_packages": attr.label(
       default = Label("//internal:packages"),

--- a/internal/js_script_and_test/rule.bzl
+++ b/internal/js_script_and_test/rule.bzl
@@ -16,7 +16,7 @@ def _js_script_impl(ctx):
   # performance by copy-pasting node_modules with hundreds of packages.
   #
   # Also generate a shell script that will run `yarn start`.
-  ctx.actions.run_shell(
+  ctx.actions.run(
     inputs = [
       ctx.attr._internal_packages[NpmPackagesInfo].installed_dir,
       ctx.attr.lib[JsLibraryInfo].npm_packages_installed_dir,
@@ -27,8 +27,10 @@ def _js_script_impl(ctx):
       ctx.outputs.compiled_dir,
       ctx.outputs.executable_file,
     ],
-    command = "NODE_PATH=" + ctx.attr._internal_packages[NpmPackagesInfo].installed_dir.path + "/node_modules node \"$@\"",
-    use_default_shell_env = True,
+    executable = ctx.file._internal_nodejs,
+    env = {
+      "NODE_PATH": ctx.attr._internal_packages[NpmPackagesInfo].installed_dir.path + "/node_modules"
+    },
     arguments = [
       # Run `node js_script/compile.js`.
       ctx.file._js_script_compile_script.path,
@@ -70,6 +72,11 @@ js_script = rule(
     "lib": attr.label(
       providers = [JsLibraryInfo],
     ),
+    "_internal_nodejs": attr.label(
+      allow_files = True,
+      single_file = True,
+      default = Label("@nodejs//:node"),
+    ),
     "_internal_packages": attr.label(
       default = Label("//internal:packages"),
     ),
@@ -94,6 +101,11 @@ js_test = rule(
     "cmd": attr.string(),
     "lib": attr.label(
       providers = [JsLibraryInfo],
+    ),
+    "_internal_nodejs": attr.label(
+      allow_files = True,
+      single_file = True,
+      default = Label("@nodejs//:node"),
     ),
     "_internal_packages": attr.label(
       default = Label("//internal:packages"),

--- a/internal/npm_packages/rule.bzl
+++ b/internal/npm_packages/rule.bzl
@@ -3,15 +3,14 @@ NpmPackagesInfo = provider(fields=[
 ])
 
 def _npm_packages_impl(ctx):
-  ctx.actions.run_shell(
+  ctx.actions.run(
     inputs = [
       ctx.file._npm_packages_install,
       ctx.file.package_json,
       ctx.file.yarn_lock,
     ],
     outputs = [ctx.outputs.installed_dir],
-    command = "node \"$@\"",
-    use_default_shell_env = True,
+    executable = ctx.file._internal_nodejs,
     arguments = [
       # Run `node npm_packages/install.js`.
       ctx.file._npm_packages_install.path,
@@ -39,6 +38,11 @@ npm_packages = rule(
     "yarn_lock": attr.label(
       allow_files = True,
       single_file = True,
+    ),
+    "_internal_nodejs": attr.label(
+      allow_files = True,
+      single_file = True,
+      default = Label("@nodejs//:node"),
     ),
     "_npm_packages_install": attr.label(
       allow_files = True,


### PR DESCRIPTION
This fixes https://github.com/zenclabs/bazel-typescript/issues/32 for the bazel-javascript repo.