### PR TITLE
Do not ignore scripts when installing packages with Yarn

### DIFF
--- a/internal/common/run_yarn.js
+++ b/internal/common/run_yarn.js
@@ -12,7 +12,7 @@ function runYarn(cwd, command = "") {
 function yarnShellCommand(cwd, command = "") {
   // Don't use the shared cache or touch the lockfile.
   // See https://github.com/yarnpkg/yarn/issues/986.
-  return `yarn --cwd ${cwd} --ignore-scripts --cache-folder ${CACHE_PATH} --frozen-lockfile ${command}`;
+  return `yarn --cwd ${cwd} --cache-folder ${CACHE_PATH} --frozen-lockfile ${command}`;
 }
 
 module.exports = {


### PR DESCRIPTION
This would otherwise prevent native modules from installing their binaries.