### PR TITLE
Use the MiniCssExtractPlugin loader in prod mode

### DIFF
--- a/internal/web_bundle/create_webpack_config.js
+++ b/internal/web_bundle/create_webpack_config.js
@@ -121,7 +121,11 @@ module.exports = (
             {
               test: /\\.module\\.css$/,
               use: [
-                "style-loader",
+                ${
+                  mode === "production"
+                    ? "MiniCssExtractPlugin.loader"
+                    : '"style-loader"'
+                },
                 {
                   loader: "css-loader",
                   options: {
@@ -134,7 +138,11 @@ module.exports = (
             {
               test: /\\.css$/,
               use: [
-                "style-loader",
+                ${
+                  mode === "production"
+                    ? "MiniCssExtractPlugin.loader"
+                    : '"style-loader"'
+                },
                 "css-loader"
               ]
             },
@@ -206,8 +214,8 @@ module.exports = (
       ${
         mode === "production"
           ? `new MiniCssExtractPlugin({
-        filename: 'static/css/[name].[contenthash:8].css',
-        chunkFilename: 'static/css/[name].[contenthash:8].chunk.css',
+        filename: '[name].[contenthash].css',
+        chunkFilename: '[name].[contenthash].chunk.css',
       }),`
           : ""
       }


### PR DESCRIPTION
Hi again, @fwouts 👋 

I noticed that the `MinCssExtractPlugin` was being wired up in the plugins, but that my bundles didn't contain `.css` files.

https://github.com/zenclabs/bazel-javascript/blob/68f8fbb/internal/web_bundle/create_webpack_config.js#L206-L213

```
Assets: 
  vendors.6da814537306d64a3dfd.js (1.12 MiB)
entrypoint size limit: The following entrypoint(s) combined asset size exceeds the recommended limit (244 KiB). This can impact web performance.
Entrypoints:
  main (1.13 MiB)
      runtime~main.6b090734559577c38d3f.js
      vendors.6da814537306d64a3dfd.js
      main.08d5e5a6765d3f845f23.js

webpack performance recommendations: 
You can limit the size of your bundles by using import() or require.ensure to lazy load some parts of your application.
For more info visit https://webpack.js.org/guides/code-splitting/
Target //web/apps/admin:prod up-to-date:
  bazel-bin/web/apps/admin/prod_bundle
```

This PR uses the `MiniCssExtractPlugin.loader` in `production` mode and `style-loader` otherwise, per https://github.com/webpack-contrib/mini-css-extract-plugin#advanced-configuration-example

My bundle now looks like:

```
Assets: 
  vendors.c8cd3ea9c2a4ad36dbb8.js (1.1 MiB)
entrypoint size limit: The following entrypoint(s) combined asset size exceeds the recommended limit (244 KiB). This can impact web performance.
Entrypoints:
  main (1.12 MiB)
      runtime~main.6b090734559577c38d3f.js
      vendors.c8cd3ea9c2a4ad36dbb8.chunk.css
      vendors.c8cd3ea9c2a4ad36dbb8.js
      main.e6e96dba7f6f5e6ee764.chunk.css
      main.e6e96dba7f6f5e6ee764.js

webpack performance recommendations: 
You can limit the size of your bundles by using import() or require.ensure to lazy load some parts of your application.
For more info visit https://webpack.js.org/guides/code-splitting/
Target //web/apps/admin:prod up-to-date:
  bazel-bin/web/apps/admin/prod_bundle
```

Thanks again for these rules!