### PR TITLE
Internal yarn

### DIFF
--- a/internal/common/run_yarn.js
+++ b/internal/common/run_yarn.js
@@ -9,11 +9,11 @@ function runYarn(cwd, command = "") {
   });
 }
 
-function yarnShellCommand(cwd, command = "") {
+function yarnShellCommand(cwd, command = "", yarn = "yarn") {
   // Don't use the shared cache or touch the lockfile.
   // See https://github.com/yarnpkg/yarn/issues/986.
   const cachePath = path.resolve(cwd, CACHE_PATH);
-  return `yarn --cwd ${cwd} --cache-folder ${cachePath} --frozen-lockfile ${command}`;
+  return `${yarn} --cwd ${cwd} --cache-folder ${cachePath} --frozen-lockfile ${command}`;
 }
 
 module.exports = {

--- a/internal/common/run_yarn.js
+++ b/internal/common/run_yarn.js
@@ -3,13 +3,13 @@ const path = require("path");
 
 const CACHE_PATH = "./node_modules_cache";
 
-function runYarn(cwd, command = "") {
-  child_process.execSync(yarnShellCommand(cwd, command), {
+function runYarn(yarn, cwd, command = "") {
+  child_process.execSync(yarnShellCommand(yarn, cwd, command), {
     stdio: "inherit"
   });
 }
 
-function yarnShellCommand(cwd, command = "", yarn = "yarn") {
+function yarnShellCommand(yarn, cwd, command = "") {
   // Don't use the shared cache or touch the lockfile.
   // See https://github.com/yarnpkg/yarn/issues/986.
   const cachePath = path.resolve(cwd, CACHE_PATH);

--- a/internal/js_script_and_test/compile.js
+++ b/internal/js_script_and_test/compile.js
@@ -50,7 +50,7 @@ export NODE_PATH=${path.relative(
   )}/node_modules
 export GENDIR=${process.env.GENDIR}
 export LIB_DIR=${path.dirname(libBuildfilePath)}
-${yarnShellCommand(destinationDirShort, "start", yarnPath)}
+${yarnShellCommand(yarnPath, destinationDirShort, "start")}
 `,
   "utf8"
 );

--- a/internal/js_script_and_test/compile.js
+++ b/internal/js_script_and_test/compile.js
@@ -14,7 +14,8 @@ const [
   destinationDir,
   destinationDirShort,
   libBuildfilePath,
-  executablePath
+  executablePath,
+  yarnPath
 ] = process.argv;
 
 fs.copySync(sourceDir, destinationDir);
@@ -49,7 +50,7 @@ export NODE_PATH=${path.relative(
   )}/node_modules
 export GENDIR=${process.env.GENDIR}
 export LIB_DIR=${path.dirname(libBuildfilePath)}
-${yarnShellCommand(destinationDirShort, "start")}
+${yarnShellCommand(destinationDirShort, "start", yarnPath)}
 `,
   "utf8"
 );

--- a/internal/js_script_and_test/compile.js
+++ b/internal/js_script_and_test/compile.js
@@ -47,6 +47,7 @@ export NODE_PATH=${path.relative(
     destinationDirShort,
     installedNpmPackagesDirShort
   )}/node_modules
+export GENDIR=${process.env.GENDIR}
 export LIB_DIR=${path.dirname(libBuildfilePath)}
 ${yarnShellCommand(destinationDirShort, "start")}
 `,

--- a/internal/js_script_and_test/rule.bzl
+++ b/internal/js_script_and_test/rule.bzl
@@ -52,6 +52,8 @@ def _js_script_impl(ctx):
             ctx.attr.lib[JsLibraryInfo].build_file_path,
             # Path to generate the shell script.
             ctx.outputs.executable_file.path,
+            # Path to yarn
+            ctx.file._internal_yarn.path,
         ],
     )
     return [
@@ -59,6 +61,8 @@ def _js_script_impl(ctx):
             executable = ctx.outputs.executable_file,
             runfiles = ctx.runfiles(
                 files = [
+                    ctx.file._internal_yarn,
+                    ctx.file._internal_nodejs,
                     ctx.attr.lib[JsLibraryInfo].npm_packages_installed_dir,
                     ctx.outputs.compiled_dir,
                 ],
@@ -76,6 +80,11 @@ js_script = rule(
             allow_files = True,
             single_file = True,
             default = Label("@nodejs//:node"),
+        ),
+        "_internal_yarn": attr.label(
+            allow_files = True,
+            single_file = True,
+            default = Label("@nodejs//:bin/yarn"),
         ),
         "_internal_packages": attr.label(
             default = Label("//internal:packages"),
@@ -109,6 +118,11 @@ js_test = rule(
             allow_files = True,
             single_file = True,
             default = Label("@nodejs//:node"),
+        ),
+        "_internal_yarn": attr.label(
+            allow_files = True,
+            single_file = True,
+            default = Label("@nodejs//:bin/yarn"),
         ),
         "_internal_packages": attr.label(
             default = Label("//internal:packages"),

--- a/internal/js_script_and_test/rule.bzl
+++ b/internal/js_script_and_test/rule.bzl
@@ -30,6 +30,7 @@ def _js_script_impl(ctx):
         executable = ctx.file._internal_nodejs,
         env = {
             "NODE_PATH": ctx.attr._internal_packages[NpmPackagesInfo].installed_dir.path + "/node_modules",
+            "GENDIR": ctx.var["GENDIR"],
         },
         arguments = [
             # Run `node js_script/compile.js`.

--- a/internal/npm_packages/install.js
+++ b/internal/npm_packages/install.js
@@ -12,7 +12,8 @@ const [
   scriptPath,
   packageJsonPath,
   yarnLockPath,
-  destinationDir
+  destinationDir,
+  yarnPath
 ] = process.argv;
 
 // Create the destination directory and copy package.json and yarn.lock.
@@ -27,4 +28,4 @@ fs.writeFileSync(
 );
 
 // Run `yarn`, which will install packages from NPM into node_modules/.
-runYarn(destinationDir);
+runYarn(yarnPath, destinationDir);

--- a/internal/npm_packages/rule.bzl
+++ b/internal/npm_packages/rule.bzl
@@ -11,6 +11,9 @@ def _npm_packages_impl(ctx):
         ],
         outputs = [ctx.outputs.installed_dir],
         executable = ctx.file._internal_nodejs,
+        tools = depset(
+            items = [ctx.file._internal_yarn],
+        ),
         arguments = [
             # Run `node npm_packages/install.js`.
             ctx.file._npm_packages_install.path,
@@ -20,6 +23,8 @@ def _npm_packages_impl(ctx):
             ctx.file.yarn_lock.path,
             # Path to install into (node_modules/ will be created there).
             ctx.outputs.installed_dir.path,
+            # Path to yarn
+            ctx.file._internal_yarn.path,
         ],
     )
     return [
@@ -39,6 +44,11 @@ npm_packages = rule(
             allow_files = True,
             single_file = True,
             mandatory = True,
+        ),
+        "_internal_yarn": attr.label(
+            allow_files = True,
+            single_file = True,
+            default = Label("@nodejs//:bin/yarn"),
         ),
         "_internal_nodejs": attr.label(
             allow_files = True,

--- a/internal/web_bundle/create_webpack_config.js
+++ b/internal/web_bundle/create_webpack_config.js
@@ -52,6 +52,9 @@ module.exports = (
   const OptimizeCSSAssetsPlugin = require(path.resolve(\`\${loadersNpmPackagesDir}/node_modules/optimize-css-assets-webpack-plugin\`));
   const UglifyJsPlugin = require(path.resolve(\`\${loadersNpmPackagesDir}/node_modules/uglifyjs-webpack-plugin\`));
 
+  const base = path.join(process.cwd(), sourceDir)
+  const gendir = path.join(base, process.env["GENDIR"], '..', 'bin')
+
   return {
     entry: (sourceDir.startsWith("/") ? "" : "./") + path.join(
       sourceDir,
@@ -63,20 +66,20 @@ module.exports = (
       path: path.resolve(outputBundleDir),
       publicPath: "${publicPath}",
       ${
-        optionalLibrary
-          ? `library: "${libraryName}",
+  optionalLibrary
+    ? `library: "${libraryName}",
       libraryTarget: "${libraryTarget}",
       `
-          : ""
-      }
+    : ""
+  }
     },
     mode: "${mode}",
     bail: ${mode === "production" ? "true" : "false"},
     target: "web",
     optimization: {
       ${
-        mode === "production"
-          ? `minimizer: [
+  mode === "production"
+    ? `minimizer: [
         new UglifyJsPlugin({
           uglifyOptions: {
             parse: {
@@ -102,17 +105,17 @@ module.exports = (
         }),
         new OptimizeCSSAssetsPlugin(),
       ],`
-          : ""
-      }
+    : ""
+  }
       ${
-        splitChunks
-          ? `splitChunks: {
+  splitChunks
+    ? `splitChunks: {
         chunks: 'all',
         name: 'vendors',
       },
       runtimeChunk: true,`
-          : ""
-      }
+    : ""
+  }
     },
     module: {
       rules: [
@@ -122,10 +125,10 @@ module.exports = (
               test: /\\.module\\.css$/,
               use: [
                 ${
-                  mode === "production"
-                    ? "MiniCssExtractPlugin.loader"
-                    : '"style-loader"'
-                },
+  mode === "production"
+    ? "MiniCssExtractPlugin.loader"
+    : '"style-loader"'
+  },
                 {
                   loader: "css-loader",
                   options: {
@@ -139,10 +142,10 @@ module.exports = (
               test: /\\.module\\.scss$/,
               use: [
                 ${
-                  mode === "production"
-                    ? "MiniCssExtractPlugin.loader"
-                    : '"style-loader"'
-                },
+  mode === "production"
+    ? "MiniCssExtractPlugin.loader"
+    : '"style-loader"'
+  },
                 {
                   loader: "css-loader",
                   options: {
@@ -158,10 +161,10 @@ module.exports = (
               test: /\\.css$/,
               use: [
                 ${
-                  mode === "production"
-                    ? "MiniCssExtractPlugin.loader"
-                    : '"style-loader"'
-                },
+  mode === "production"
+    ? "MiniCssExtractPlugin.loader"
+    : '"style-loader"'
+  },
                 "css-loader"
               ]
             },
@@ -169,10 +172,10 @@ module.exports = (
               test: /\\.scss$/,
               use: [
                 ${
-                  mode === "production"
-                    ? "MiniCssExtractPlugin.loader"
-                    : '"style-loader"'
-                },
+  mode === "production"
+    ? "MiniCssExtractPlugin.loader"
+    : '"style-loader"'
+  },
                 {
                   loader: "css-loader",
                   options: {
@@ -211,7 +214,9 @@ module.exports = (
       modules: [
         path.join(installedNpmPackagesDir, "node_modules"),
         // Necessary for webpack-hot-client with the dev server.
-        path.join(loadersNpmPackagesDir, "node_modules")
+        path.join(loadersNpmPackagesDir, "node_modules"),
+        base,
+        gendir,
       ]
     },
     resolveLoader: {
@@ -225,8 +230,8 @@ module.exports = (
           template: htmlTemplatePath,
           inject: true,
           ${
-            mode === "production"
-              ? `minify: {
+  mode === "production"
+    ? `minify: {
             removeComments: true,
             collapseWhitespace: true,
             removeRedundantAttributes: true,
@@ -238,8 +243,8 @@ module.exports = (
             minifyCSS: true,
             minifyURLs: true,
           }`
-              : ""
-          }
+    : ""
+  }
         })]
         : []
       ),
@@ -248,21 +253,21 @@ module.exports = (
         NODE_ENV: "${mode}",
       }),
       ${
-        mode === "production"
-          ? `new MiniCssExtractPlugin({
+  mode === "production"
+    ? `new MiniCssExtractPlugin({
         filename: '[name].[contenthash].css',
         chunkFilename: '[name].[contenthash].chunk.css',
       }),`
-          : ""
-      }
+    : ""
+  }
       ${
-        // Chunk splitting is enabled by default.
-        splitChunks
-          ? `new webpack.optimize.LimitChunkCountPlugin({
+  // Chunk splitting is enabled by default.
+  splitChunks
+    ? `new webpack.optimize.LimitChunkCountPlugin({
         maxChunks: 1
       }),`
-          : ""
-      }
+    : ""
+  }
     ]
   };
 }

--- a/internal/web_bundle/create_webpack_config.js
+++ b/internal/web_bundle/create_webpack_config.js
@@ -11,8 +11,22 @@ const [
   optionalLibrary,
   splitChunksStr,
   publicPath,
-  webpackConfigPath
+  webpackConfigPath,
+  joinedExternals
 ] = process.argv;
+
+const externals = joinedExternals
+  .split("|")
+  .map(extTuple => extTuple.split(":", 2))
+  .reduce((exts, [k, v]) => {
+    if (k == "") {
+      return exts;
+    }
+
+    exts.push(`"${k}": "${v}"`);
+    return exts;
+  }, [])
+  .join(",");
 
 const [libraryName, libraryTarget] = optionalLibrary.split("/");
 const splitChunks = splitChunksStr === "1";
@@ -73,6 +87,7 @@ module.exports = (
           : ""
       }
     },
+    externals: {${externals}},
     mode: "${mode}",
     bail: ${mode === "production" ? "true" : "false"},
     target: "web",

--- a/internal/web_bundle/create_webpack_config.js
+++ b/internal/web_bundle/create_webpack_config.js
@@ -66,20 +66,20 @@ module.exports = (
       path: path.resolve(outputBundleDir),
       publicPath: "${publicPath}",
       ${
-  optionalLibrary
-    ? `library: "${libraryName}",
+        optionalLibrary
+          ? `library: "${libraryName}",
       libraryTarget: "${libraryTarget}",
       `
-    : ""
-  }
+          : ""
+      }
     },
     mode: "${mode}",
     bail: ${mode === "production" ? "true" : "false"},
     target: "web",
     optimization: {
       ${
-  mode === "production"
-    ? `minimizer: [
+        mode === "production"
+          ? `minimizer: [
         new UglifyJsPlugin({
           uglifyOptions: {
             parse: {
@@ -105,17 +105,17 @@ module.exports = (
         }),
         new OptimizeCSSAssetsPlugin(),
       ],`
-    : ""
-  }
+          : ""
+      }
       ${
-  splitChunks
-    ? `splitChunks: {
+        splitChunks
+          ? `splitChunks: {
         chunks: 'all',
         name: 'vendors',
       },
       runtimeChunk: true,`
-    : ""
-  }
+          : ""
+      }
     },
     module: {
       rules: [
@@ -125,10 +125,10 @@ module.exports = (
               test: /\\.module\\.css$/,
               use: [
                 ${
-  mode === "production"
-    ? "MiniCssExtractPlugin.loader"
-    : '"style-loader"'
-  },
+                  mode === "production"
+                    ? "MiniCssExtractPlugin.loader"
+                    : '"style-loader"'
+                },
                 {
                   loader: "css-loader",
                   options: {
@@ -142,10 +142,10 @@ module.exports = (
               test: /\\.module\\.scss$/,
               use: [
                 ${
-  mode === "production"
-    ? "MiniCssExtractPlugin.loader"
-    : '"style-loader"'
-  },
+                  mode === "production"
+                    ? "MiniCssExtractPlugin.loader"
+                    : '"style-loader"'
+                },
                 {
                   loader: "css-loader",
                   options: {
@@ -161,10 +161,10 @@ module.exports = (
               test: /\\.css$/,
               use: [
                 ${
-  mode === "production"
-    ? "MiniCssExtractPlugin.loader"
-    : '"style-loader"'
-  },
+                  mode === "production"
+                    ? "MiniCssExtractPlugin.loader"
+                    : '"style-loader"'
+                },
                 "css-loader"
               ]
             },
@@ -172,10 +172,10 @@ module.exports = (
               test: /\\.scss$/,
               use: [
                 ${
-  mode === "production"
-    ? "MiniCssExtractPlugin.loader"
-    : '"style-loader"'
-  },
+                  mode === "production"
+                    ? "MiniCssExtractPlugin.loader"
+                    : '"style-loader"'
+                },
                 {
                   loader: "css-loader",
                   options: {
@@ -230,8 +230,8 @@ module.exports = (
           template: htmlTemplatePath,
           inject: true,
           ${
-  mode === "production"
-    ? `minify: {
+            mode === "production"
+              ? `minify: {
             removeComments: true,
             collapseWhitespace: true,
             removeRedundantAttributes: true,
@@ -243,8 +243,8 @@ module.exports = (
             minifyCSS: true,
             minifyURLs: true,
           }`
-    : ""
-  }
+              : ""
+          }
         })]
         : []
       ),
@@ -253,21 +253,21 @@ module.exports = (
         NODE_ENV: "${mode}",
       }),
       ${
-  mode === "production"
-    ? `new MiniCssExtractPlugin({
+        mode === "production"
+          ? `new MiniCssExtractPlugin({
         filename: '[name].[contenthash].css',
         chunkFilename: '[name].[contenthash].chunk.css',
       }),`
-    : ""
-  }
+          : ""
+      }
       ${
-  // Chunk splitting is enabled by default.
-  splitChunks
-    ? `new webpack.optimize.LimitChunkCountPlugin({
+        // Chunk splitting is enabled by default.
+        splitChunks
+          ? `new webpack.optimize.LimitChunkCountPlugin({
         maxChunks: 1
       }),`
-    : ""
-  }
+          : ""
+      }
     ]
   };
 }

--- a/internal/web_bundle/rule.bzl
+++ b/internal/web_bundle/rule.bzl
@@ -225,6 +225,7 @@ def _create_webpack_config(ctx):
         executable = ctx.file._internal_nodejs,
         env = {
             "NODE_PATH": ctx.attr._internal_packages[NpmPackagesInfo].installed_dir.path + "/node_modules",
+            "GENDIR": ctx.var["GENDIR"],
         },
         arguments = [
             # Run `node web_bundle/create_webpack_config.js`.
@@ -245,6 +246,11 @@ def _create_webpack_config(ctx):
             ctx.attr.public_path,
             # Path where to create the Webpack config.
             webpack_config.path,
+            # Externals definitions
+            ("|".join([
+                key + ":" + value
+                for key, value in ctx.attr.externals.items()
+            ])),
         ],
     )
 
@@ -260,6 +266,7 @@ _ATTRS = {
         providers = [JsModuleInfo],
     ),
     "env": attr.string_dict(),
+    "externals": attr.string_dict(),
     "entry": attr.string(
         mandatory = True,
     ),

--- a/internal/web_bundle/rule.bzl
+++ b/internal/web_bundle/rule.bzl
@@ -23,6 +23,7 @@ def _web_bundle_impl(ctx):
         executable = ctx.file._internal_nodejs,
         env = {
             "NODE_PATH": ctx.attr._internal_packages[NpmPackagesInfo].installed_dir.path + "/node_modules",
+            "GENDIR": ctx.var["GENDIR"],
         },
         arguments = [
             # Run `node web_bundle/compile.js`.

--- a/internal/web_bundle/rule.bzl
+++ b/internal/web_bundle/rule.bzl
@@ -207,6 +207,9 @@ def _strip_buildfile(path):
 def _create_webpack_config(ctx):
     webpack_config = ctx.actions.declare_file(ctx.label.name + ".webpack.config.js")
 
+    mode_arg = ctx.attr.mode
+    mode_arg = ctx.expand_make_variables("mode", mode_arg, {})
+
     # Create the Webpack config file.
     ctx.actions.run(
         inputs = [
@@ -232,7 +235,7 @@ def _create_webpack_config(ctx):
             # Output file name (e.g. "bundle.js").
             ctx.attr.output,
             # Mode for Webpack.
-            ctx.attr.mode,
+            mode_arg,
             # Library for Webpack (optional).
             ctx.attr.library_name + "/" + ctx.attr.library_target if ctx.attr.library_name else "",
             # Enable split chunks or not.
@@ -263,11 +266,6 @@ _ATTRS = {
         default = "bundle.js",
     ),
     "mode": attr.string(
-        values = [
-            "none",
-            "development",
-            "production",
-        ],
         default = "none",
     ),
     "split_chunks": attr.bool(


### PR DESCRIPTION
This PR updates `js_test` and `js_script` to use bazel-managed yarn binary instead of relying on the host having it installed.

