### PR TITLE
Remove transitive loads

### DIFF
--- a/defs.bzl
+++ b/defs.bzl
@@ -1,8 +1,8 @@
 load("//internal/js_binary:rule.bzl", _js_binary = "js_binary")
 load(
     "//internal/js_library:rule.bzl",
-    _JsLibraryInfo = "JsLibraryInfo",
     _js_library = "js_library",
+    _JsLibraryInfo = "JsLibraryInfo",
 )
 load("//internal/js_module:rule.bzl", _js_module = "js_module")
 load(
@@ -15,8 +15,8 @@ load("//internal/ts_library:rule.bzl", _ts_library = "ts_library")
 load("//internal/web_bundle:rule.bzl", _web_bundle = "web_bundle")
 load(
     "//internal/npm_packages:rule.bzl",
-    _NpmPackagesInfo = "NpmPackagesInfo",
     _npm_packages = "npm_packages",
+    _NpmPackagesInfo = "NpmPackagesInfo",
 )
 
 js_binary = _js_binary

--- a/defs.bzl
+++ b/defs.bzl
@@ -1,8 +1,31 @@
-load("//internal/js_library:rule.bzl", "JsLibraryInfo", "js_library")
-load("//internal/ts_library:rule.bzl", "ts_library")
-load("//internal/js_module:rule.bzl", "js_module")
-load("//internal/js_binary:rule.bzl", "js_binary")
-load("//internal/web_bundle:rule.bzl", "web_bundle")
-load("//internal/js_script_and_test:rule.bzl", "js_script", "js_test")
-load("//internal/npm_packages:rule.bzl", "NpmPackagesInfo", "npm_packages")
-load("//internal/npm_binary:rule.bzl", "npm_binary")
+load("//internal/js_binary:rule.bzl", _js_binary = "js_binary")
+load(
+    "//internal/js_library:rule.bzl",
+    _JsLibraryInfo = "JsLibraryInfo",
+    _js_library = "js_library",
+)
+load("//internal/js_module:rule.bzl", _js_module = "js_module")
+load(
+    "//internal/js_script_and_test:rule.bzl",
+    _js_script = "js_script",
+    _js_test = "js_test",
+)
+load("//internal/npm_binary:rule.bzl", _npm_binary = "npm_binary")
+load("//internal/ts_library:rule.bzl", _ts_library = "ts_library")
+load("//internal/web_bundle:rule.bzl", _web_bundle = "web_bundle")
+load(
+    "//internal/npm_packages:rule.bzl",
+    _NpmPackagesInfo = "NpmPackagesInfo",
+    _npm_packages = "npm_packages",
+)
+
+js_binary = _js_binary
+js_library = _js_library
+js_module = _js_module
+js_script = _js_script
+js_test = _js_test
+JsLibraryInfo = _JsLibraryInfo
+npm_binary = _npm_binary
+npm_packages = _npm_packages
+NpmPackagesInfo = _NpmPackagesInfo
+web_bundle = _web_bundle

--- a/defs.bzl
+++ b/defs.bzl
@@ -28,4 +28,5 @@ JsLibraryInfo = _JsLibraryInfo
 npm_binary = _npm_binary
 npm_packages = _npm_packages
 NpmPackagesInfo = _NpmPackagesInfo
+ts_library = _ts_library
 web_bundle = _web_bundle

--- a/defs.bzl
+++ b/defs.bzl
@@ -1,8 +1,8 @@
 load("//internal/js_binary:rule.bzl", _js_binary = "js_binary")
 load(
     "//internal/js_library:rule.bzl",
-    _js_library = "js_library",
     _JsLibraryInfo = "JsLibraryInfo",
+    _js_library = "js_library",
 )
 load("//internal/js_module:rule.bzl", _js_module = "js_module")
 load(
@@ -13,20 +13,20 @@ load(
 load("//internal/npm_binary:rule.bzl", _npm_binary = "npm_binary")
 load(
     "//internal/npm_packages:rule.bzl",
-    _npm_packages = "npm_packages",
     _NpmPackagesInfo = "NpmPackagesInfo",
+    _npm_packages = "npm_packages",
 )
 load("//internal/ts_library:rule.bzl", _ts_library = "ts_library")
 load("//internal/web_bundle:rule.bzl", _web_bundle = "web_bundle")
 
+JsLibraryInfo = _JsLibraryInfo
 js_binary = _js_binary
 js_library = _js_library
 js_module = _js_module
 js_script = _js_script
 js_test = _js_test
-JsLibraryInfo = _JsLibraryInfo
+NpmPackagesInfo = _NpmPackagesInfo
 npm_binary = _npm_binary
 npm_packages = _npm_packages
-NpmPackagesInfo = _NpmPackagesInfo
 ts_library = _ts_library
 web_bundle = _web_bundle

--- a/defs.bzl
+++ b/defs.bzl
@@ -11,13 +11,13 @@ load(
     _js_test = "js_test",
 )
 load("//internal/npm_binary:rule.bzl", _npm_binary = "npm_binary")
-load("//internal/ts_library:rule.bzl", _ts_library = "ts_library")
-load("//internal/web_bundle:rule.bzl", _web_bundle = "web_bundle")
 load(
     "//internal/npm_packages:rule.bzl",
     _npm_packages = "npm_packages",
     _NpmPackagesInfo = "NpmPackagesInfo",
 )
+load("//internal/ts_library:rule.bzl", _ts_library = "ts_library")
+load("//internal/web_bundle:rule.bzl", _web_bundle = "web_bundle")
 
 js_binary = _js_binary
 js_library = _js_library


### PR DESCRIPTION
Fixes #54

This change creates explicit exports for all rules/macros in `defs.bzl` instead of relying on the deprecated behavior of implicitly exporting loaded symbols.