### PR TITLE
Ran buildifier to fix usage of single_file attribute

### DIFF
--- a/examples/node-typescript-app/services/base-image/BUILD.bazel
+++ b/examples/node-typescript-app/services/base-image/BUILD.bazel
@@ -1,6 +1,6 @@
 package(default_visibility = ["//visibility:public"])
 
-load("@io_bazel_rules_docker//container:container.bzl", "container_image", "container_push")
+load("@io_bazel_rules_docker//container:container.bzl", "container_image")
 
 ## The Backend Base Image
 container_image(

--- a/internal/js_binary/rule.bzl
+++ b/internal/js_binary/rule.bzl
@@ -57,16 +57,14 @@ js_binary = rule(
             default = "none",
         ),
         "_internal_nodejs": attr.label(
-            allow_files = True,
-            single_file = True,
+            allow_single_file = True,
             default = Label("@nodejs//:node"),
         ),
         "_internal_packages": attr.label(
             default = Label("//internal:packages"),
         ),
         "_js_binary_compile_script": attr.label(
-            allow_files = True,
-            single_file = True,
+            allow_single_file = True,
             default = Label("//internal/js_binary:compile.js"),
         ),
     },

--- a/internal/js_library/rule.bzl
+++ b/internal/js_library/rule.bzl
@@ -180,18 +180,15 @@ js_library = rule(
             default = Label("//internal:packages"),
         ),
         "_internal_nodejs": attr.label(
-            allow_files = True,
-            single_file = True,
+            allow_single_file = True,
             default = Label("@nodejs//:node"),
         ),
         "_js_library_create_full_src_script": attr.label(
-            allow_files = True,
-            single_file = True,
+            allow_single_file = True,
             default = Label("//internal/js_library:create_full_src.js"),
         ),
         "_js_library_compile_script": attr.label(
-            allow_files = True,
-            single_file = True,
+            allow_single_file = True,
             default = Label("//internal/js_library:compile.js"),
         ),
         "_empty_npm_packages": attr.label(

--- a/internal/js_script_and_test/rule.bzl
+++ b/internal/js_script_and_test/rule.bzl
@@ -77,21 +77,18 @@ js_script = rule(
             providers = [JsLibraryInfo],
         ),
         "_internal_nodejs": attr.label(
-            allow_files = True,
-            single_file = True,
+            allow_single_file = True,
             default = Label("@nodejs//:node"),
         ),
         "_internal_yarn": attr.label(
-            allow_files = True,
-            single_file = True,
+            allow_single_file = True,
             default = Label("@nodejs//:bin/yarn"),
         ),
         "_internal_packages": attr.label(
             default = Label("//internal:packages"),
         ),
         "_js_script_compile_script": attr.label(
-            allow_files = True,
-            single_file = True,
+            allow_single_file = True,
             default = Label("//internal/js_script_and_test:compile.js"),
         ),
     },
@@ -115,21 +112,18 @@ js_test = rule(
             mandatory = True,
         ),
         "_internal_nodejs": attr.label(
-            allow_files = True,
-            single_file = True,
+            allow_single_file = True,
             default = Label("@nodejs//:node"),
         ),
         "_internal_yarn": attr.label(
-            allow_files = True,
-            single_file = True,
+            allow_single_file = True,
             default = Label("@nodejs//:bin/yarn"),
         ),
         "_internal_packages": attr.label(
             default = Label("//internal:packages"),
         ),
         "_js_script_compile_script": attr.label(
-            allow_files = True,
-            single_file = True,
+            allow_single_file = True,
             default = Label("//internal/js_script_and_test:compile.js"),
         ),
     },

--- a/internal/npm_packages/rule.bzl
+++ b/internal/npm_packages/rule.bzl
@@ -36,28 +36,23 @@ def _npm_packages_impl(ctx):
 npm_packages = rule(
     attrs = {
         "package_json": attr.label(
-            allow_files = True,
-            single_file = True,
+            allow_single_file = True,
             mandatory = True,
         ),
         "yarn_lock": attr.label(
-            allow_files = True,
-            single_file = True,
+            allow_single_file = True,
             mandatory = True,
         ),
         "_internal_yarn": attr.label(
-            allow_files = True,
-            single_file = True,
+            allow_single_file = True,
             default = Label("@nodejs//:bin/yarn"),
         ),
         "_internal_nodejs": attr.label(
-            allow_files = True,
-            single_file = True,
+            allow_single_file = True,
             default = Label("@nodejs//:node"),
         ),
         "_npm_packages_install": attr.label(
-            allow_files = True,
-            single_file = True,
+            allow_single_file = True,
             default = Label("//internal/npm_packages:install.js"),
         ),
     },

--- a/internal/ts_library/rule.bzl
+++ b/internal/ts_library/rule.bzl
@@ -239,31 +239,26 @@ ts_library = rule(
             default = [],
         ),
         "tsconfig": attr.label(
-            allow_files = [".json"],
-            single_file = True,
+            allow_single_file = [".json"],
             default = Label("//internal/ts_library:default_tsconfig.json"),
         ),
         "_internal_nodejs": attr.label(
-            allow_files = True,
-            single_file = True,
+            allow_single_file = True,
             default = Label("@nodejs//:node"),
         ),
         "_internal_packages": attr.label(
             default = Label("//internal:packages"),
         ),
         "_ts_library_create_full_src_script": attr.label(
-            allow_files = True,
-            single_file = True,
+            allow_single_file = True,
             default = Label("//internal/ts_library:create_full_src.js"),
         ),
         "_ts_library_compile_script": attr.label(
-            allow_files = True,
-            single_file = True,
+            allow_single_file = True,
             default = Label("//internal/ts_library:compile.js"),
         ),
         "_ts_library_transpile_script": attr.label(
-            allow_files = True,
-            single_file = True,
+            allow_single_file = True,
             default = Label("//internal/ts_library:transpile.js"),
         ),
         "_empty_npm_packages": attr.label(

--- a/internal/web_bundle/rule.bzl
+++ b/internal/web_bundle/rule.bzl
@@ -283,8 +283,7 @@ _ATTRS = {
         default = "/",
     ),
     "html_template": attr.label(
-        allow_files = True,
-        single_file = True,
+        allow_single_file = True,
     ),
     "library_name": attr.string(),
     "library_target": attr.string(
@@ -303,26 +302,22 @@ _ATTRS = {
         default = "umd",
     ),
     "dev_server_options": attr.label(
-        allow_files = True,
-        single_file = True,
+        allow_single_file = True,
         default = Label("//internal/web_bundle:dev_server_options.js"),
     ),
     "_internal_nodejs": attr.label(
-        allow_files = True,
-        single_file = True,
+        allow_single_file = True,
         default = Label("@nodejs//:node"),
     ),
     "_internal_packages": attr.label(
         default = Label("//internal:packages"),
     ),
     "_web_bundle_compile_script": attr.label(
-        allow_files = True,
-        single_file = True,
+        allow_single_file = True,
         default = Label("//internal/web_bundle:compile.js"),
     ),
     "_web_bundle_create_webpack_config_script": attr.label(
-        allow_files = True,
-        single_file = True,
+        allow_single_file = True,
         default = Label("//internal/web_bundle:create_webpack_config.js"),
     ),
 }

--- a/tests/ts-example/src/BUILD.bazel
+++ b/tests/ts-example/src/BUILD.bazel
@@ -1,7 +1,6 @@
 package(default_visibility = ["//visibility:public"])
 
-load("//:defs.bzl", "js_binary")
-load("//:defs.bzl", "ts_library")
+load("//:defs.bzl", "js_binary", "ts_library")
 
 js_binary(
     name = "app",

--- a/tests/ts-example/src/testing/BUILD.bazel
+++ b/tests/ts-example/src/testing/BUILD.bazel
@@ -1,7 +1,6 @@
 package(default_visibility = ["//visibility:public"])
 
-load("//:defs.bzl", "js_test")
-load("//:defs.bzl", "ts_library")
+load("//:defs.bzl", "js_test", "ts_library")
 
 ts_library(
     name = "sum",


### PR DESCRIPTION
Fixes #56

This change is the result of running `buildifier --lint=fix` on all Starlark and BUILD files, which automatically changed all usages of the `single_file` and `allow_files` attributes to `allow_single_file`. This avoids the need to pass `--incompatible_disable_deprecated_attr_params` when Bazel 0.27 becomes available.

It also cleaned up a few load statements as a side effect.